### PR TITLE
fix: fix mysql2 invalid configuration option poolWaitTimeout

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -67,7 +67,7 @@ export class RDSClient extends Operator {
   constructor(options: RDSClientOptions) {
     super();
     options.connectTimeout = options.connectTimeout ?? 500;
-    const { connectionStorage, connectionStorageKey, ...mysqlOptions } = options;
+    const { connectionStorage, connectionStorageKey, poolWaitTimeout, ...mysqlOptions } = options;
     // get connection options from getConnectionConfig method every time
     if (mysqlOptions.getConnectionConfig) {
       this.#pool = new Pool({ config: new RDSPoolConfig(mysqlOptions, mysqlOptions.getConnectionConfig) } as any) as unknown as PoolPromisify;
@@ -83,7 +83,7 @@ export class RDSClient extends Operator {
     });
     this.#connectionStorage = connectionStorage || new AsyncLocalStorage();
     this.#connectionStorageKey = connectionStorageKey || RDSClient.#DEFAULT_STORAGE_KEY;
-    this.#poolWaitTimeout = options.poolWaitTimeout ?? 500;
+    this.#poolWaitTimeout = poolWaitTimeout ?? 500;
     // https://github.com/mysqljs/mysql#pool-events
     this.#pool.on('connection', (connection: PoolConnectionPromisify) => {
       channels.connectionNew.publish({


### PR DESCRIPTION
Unpicked `options` will become `mysqlOptions` and pass to mysql2, mean while mysql2 will console.error a message, causing egg fail to start.

![image](https://github.com/user-attachments/assets/19bb92fa-1c98-4e7b-8195-5cf7ff303e1d)
![image](https://github.com/user-attachments/assets/88108c2b-ef9e-4c34-b74b-93cb609101b3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced configurability of the RDSClient by adding a `poolWaitTimeout` option for improved connection management.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->